### PR TITLE
Update urtconnector-0.9.0-r1.ebuild

### DIFF
--- a/games-util/urtconnector/urtconnector-0.9.0-r1.ebuild
+++ b/games-util/urtconnector/urtconnector-0.9.0-r1.ebuild
@@ -19,7 +19,9 @@ IUSE=""
 RDEPEND="dev-qt/qtgui:4
 games-util/qstat
 >=dev-libs/boost-1.59.0
-dev-db/sqlite:3"
+dev-db/sqlite:3
+>=media-libs/phonon-4.9.0"
+
 
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Added media-libs/phonon dependency.
emerge failed during cmake config without media-libs/phonon dependency installed.