### PR TITLE
Fix invalid INSTALLDIR

### DIFF
--- a/mail-filter/dovecot-antispam/dovecot-antispam-9999.ebuild
+++ b/mail-filter/dovecot-antispam/dovecot-antispam-9999.ebuild
@@ -22,7 +22,7 @@ DOCS=( README )
 
 src_install() {
 	mkdir -p "${D}/usr/lib64/dovecot"
-	emake DESTDIR="${D}" INSTALLDIR="usr/lib64/dovecot" install
+	emake DESTDIR="${D}" INSTALLDIR="/usr/lib64/dovecot" install
 
 	newman antispam.7 dovecot-antispam.7
 


### PR DESCRIPTION
Fixes error in install due to missing directory separator.

```
>>> Install mail-filter/dovecot-antispam-9999 into /var/tmp/portage/mail-filter/dovecot-antispam-9999/image
make -j4 DESTDIR=/var/tmp/portage/mail-filter/dovecot-antispam-9999/image INSTALLDIR=usr/lib64/dovecot install 
Installation directory /var/tmp/portage/mail-filter/dovecot-antispam-9999/imageusr/lib64/dovecot/ doesn't exist,
run make install INSTALLDIR=...
make: *** [Makefile:64: checkinstalldir] Error 2
 * ERROR: mail-filter/dovecot-antispam-9999::hering-overlay failed (install phase):
 *   emake failed
 * 
 * If you need support, post the output of `emerge --info '=mail-filter/dovecot-antispam-9999::hering-overlay'`,
 * the complete build log and the output of `emerge -pqv '=mail-filter/dovecot-antispam-9999::hering-overlay'`.
 * The complete build log is located at '/var/tmp/portage/mail-filter/dovecot-antispam-9999/temp/build.log'.
 * The ebuild environment file is located at '/var/tmp/portage/mail-filter/dovecot-antispam-9999/temp/environment'.
 * Working directory: '/var/tmp/portage/mail-filter/dovecot-antispam-9999/work/dovecot-antispam-9999'
 * S: '/var/tmp/portage/mail-filter/dovecot-antispam-9999/work/dovecot-antispam-9999'
```