### PR TITLE
Update --prefix to fix QA notice

### DIFF
--- a/net-mail/dovecot-fts-flatcurve/dovecot-fts-flatcurve-9999.ebuild
+++ b/net-mail/dovecot-fts-flatcurve/dovecot-fts-flatcurve-9999.ebuild
@@ -18,5 +18,5 @@ dev-libs/xapian"
 
 src_configure() {
 	./autogen.sh
-	./configure --with-dovecot=/usr/lib64/dovecot
+	./configure --prefix=/usr --with-dovecot=/usr/lib64/dovecot
 }


### PR DESCRIPTION
Fixes #12 QA notice about header files installed in /usr/local (default prefix if none given)